### PR TITLE
Updated MPI_Type in case of compiling with OpenMPI and fix for 1 memory leak

### DIFF
--- a/fields/EMfields3D.cpp
+++ b/fields/EMfields3D.cpp
@@ -262,30 +262,57 @@ EMfields3D::EMfields3D(Collective * col, Grid * grid, VirtualTopology3D *vct) :
     MPI_Type_commit(&yzFacetypeC);
     
     //For face exchange on Y dir
-    MPI_Type_hvector((nxc-2),(nzc-2),(nzc*nyc*sizeof(double)), MPI_DOUBLE, &xzFacetypeC);
+    //MPI_Type_hvector((nxc-2),(nzc-2),(nzc*nyc*sizeof(double)), MPI_DOUBLE, &xzFacetypeC);
+#ifdef OMPI_MPI_H
+    MPI_Type_create_hvector((nxc-2), (nzc-2), (nzc*nyc*sizeof(double)), MPI_DOUBLE, &xzFacetypeC);
+#else
+    MPI_Type_hvector((nxc-2), (nzc-2), (nzc*nyc*sizeof(double)), MPI_DOUBLE, &xzFacetypeC);
+#endif
     MPI_Type_commit(&xzFacetypeC);
 
     MPI_Type_vector((nyc-2), 1, nzc, MPI_DOUBLE, &yEdgetypeC);
     MPI_Type_commit(&yEdgetypeC);
     
-    //For face exchangeg on Z dir
+    //For face exchange on Z dir
+    //MPI_Type_hvector((nxc-2), 1, (nzc*nyc*sizeof(double)), yEdgetypeC, &xyFacetypeC);
+#ifdef OMPI_MPI_H
+    MPI_Type_create_hvector((nxc-2), 1, (nzc*nyc*sizeof(double)), yEdgetypeC, &xyFacetypeC);
+#else
     MPI_Type_hvector((nxc-2), 1, (nzc*nyc*sizeof(double)), yEdgetypeC, &xyFacetypeC);
+#endif
     MPI_Type_commit(&xyFacetypeC);
-    
+
     //2 yEdgeType can be merged into one message
+    //MPI_Type_hvector(2, 1,(nzc-1)*sizeof(double), yEdgetypeC, &yEdgetypeC2);
+#ifdef OMPI_MPI_H
+    MPI_Type_create_hvector(2, 1,(nzc-1)*sizeof(double), yEdgetypeC, &yEdgetypeC2);
+#else
     MPI_Type_hvector(2, 1,(nzc-1)*sizeof(double), yEdgetypeC, &yEdgetypeC2);
+#endif
     MPI_Type_commit(&yEdgetypeC2);
+
     
     MPI_Type_contiguous((nzc-2),MPI_DOUBLE, &zEdgetypeC);
     MPI_Type_commit(&zEdgetypeC);
     
+    //MPI_Type_hvector(2, (nzc-2),(nxc-1)*(nyc*nzc)*sizeof(double), MPI_DOUBLE, &zEdgetypeC2);
+#ifdef OMPI_MPI_H
+    MPI_Type_create_hvector(2, (nzc-2),(nxc-1)*(nyc*nzc)*sizeof(double), MPI_DOUBLE, &zEdgetypeC2);
+#else
     MPI_Type_hvector(2, (nzc-2),(nxc-1)*(nyc*nzc)*sizeof(double), MPI_DOUBLE, &zEdgetypeC2);
+#endif
     MPI_Type_commit(&zEdgetypeC2);
-    
+
     MPI_Type_vector((nxc-2), 1, nyc*nzc, MPI_DOUBLE, &xEdgetypeC);
     MPI_Type_commit(&xEdgetypeC);
+    //MPI_Type_hvector(2, 1, (nyc-1)*nzc*sizeof(double), xEdgetypeC, &xEdgetypeC2);
+#ifdef OMPI_MPI_H
+    MPI_Type_create_hvector(2, 1, (nyc-1)*nzc*sizeof(double), xEdgetypeC, &xEdgetypeC2);
+#else
     MPI_Type_hvector(2, 1, (nyc-1)*nzc*sizeof(double), xEdgetypeC, &xEdgetypeC2);
+#endif
     MPI_Type_commit(&xEdgetypeC2);
+
     
     //corner used to communicate in x direction
     int blocklengthC[]={1,1,1,1};
@@ -301,29 +328,58 @@ EMfields3D::EMfields3D(Collective * col, Grid * grid, VirtualTopology3D *vct) :
     MPI_Type_commit(&yzFacetypeN);
 
     //For face exchange on Y dir
+    //MPI_Type_hvector((nxn-2),(nzn-2),(nzn*nyn*sizeof(double)), MPI_DOUBLE, &xzFacetypeN);
+    //MPI_Type_commit(&xzFacetypeN);
+#ifdef OMPI_MPI_H
+    MPI_Type_create_hvector((nxn-2),(nzn-2),(nzn*nyn*sizeof(double)), MPI_DOUBLE, &xzFacetypeN);
+#else
     MPI_Type_hvector((nxn-2),(nzn-2),(nzn*nyn*sizeof(double)), MPI_DOUBLE, &xzFacetypeN);
+#endif
     MPI_Type_commit(&xzFacetypeN);
+
 
     MPI_Type_vector((nyn-2), 1, nzn, MPI_DOUBLE, &yEdgetypeN);
     MPI_Type_commit(&yEdgetypeN);
 
     //For face exchangeg on Z dir
+    //MPI_Type_hvector((nxn-2), 1, (nzn*nyn*sizeof(double)), yEdgetypeN, &xyFacetypeN);
+#ifdef OMPI_MPI_H
+    MPI_Type_create_hvector((nxn-2), 1, (nzn*nyn*sizeof(double)), yEdgetypeN, &xyFacetypeN);
+#else
     MPI_Type_hvector((nxn-2), 1, (nzn*nyn*sizeof(double)), yEdgetypeN, &xyFacetypeN);
+#endif
     MPI_Type_commit(&xyFacetypeN);
 
     //2 yEdgeType can be merged into one message
+    //MPI_Type_hvector(2, 1,(nzn-1)*sizeof(double), yEdgetypeN, &yEdgetypeN2);
+#ifdef OMPI_MPI_H
+    MPI_Type_create_hvector(2, 1,(nzn-1)*sizeof(double), yEdgetypeN, &yEdgetypeN2);
+#else
     MPI_Type_hvector(2, 1,(nzn-1)*sizeof(double), yEdgetypeN, &yEdgetypeN2);
+#endif
     MPI_Type_commit(&yEdgetypeN2);
 
     MPI_Type_contiguous((nzn-2),MPI_DOUBLE, &zEdgetypeN);
     MPI_Type_commit(&zEdgetypeN);
 
+    //MPI_Type_hvector(2, (nzn-2),(nxn-1)*(nyn*nzn)*sizeof(double), MPI_DOUBLE, &zEdgetypeN2);
+#ifdef OMPI_MPI_H
+    MPI_Type_create_hvector(2, (nzn-2),(nxn-1)*(nyn*nzn)*sizeof(double), MPI_DOUBLE, &zEdgetypeN2);
+#else
     MPI_Type_hvector(2, (nzn-2),(nxn-1)*(nyn*nzn)*sizeof(double), MPI_DOUBLE, &zEdgetypeN2);
+#endif
     MPI_Type_commit(&zEdgetypeN2);
+
+
 
     MPI_Type_vector((nxn-2), 1, nyn*nzn, MPI_DOUBLE, &xEdgetypeN);
     MPI_Type_commit(&xEdgetypeN);
+    //MPI_Type_hvector(2, 1, (nyn-1)*nzn*sizeof(double), xEdgetypeN, &xEdgetypeN2);
+#ifdef OMPI_MPI_H
+    MPI_Type_create_hvector(2, 1, (nyn-1)*nzn*sizeof(double), xEdgetypeN, &xEdgetypeN2);
+#else
     MPI_Type_hvector(2, 1, (nyn-1)*nzn*sizeof(double), xEdgetypeN, &xEdgetypeN2);
+#endif
     MPI_Type_commit(&xEdgetypeN2);
 
     //corner used to communicate in x direction

--- a/main/iPIC3Dlib.cpp
+++ b/main/iPIC3Dlib.cpp
@@ -81,6 +81,7 @@ c_Solver::~c_Solver()
   delete [] momentum;
   delete [] Qremoved;
   delete my_clock;
+  delete [] BulkEnergy;
 }
 
 int c_Solver::Init(int argc, char **argv) {


### PR DESCRIPTION
Please let me know if there is anything you would like me to change.

1. Change from MPI_Type_hvector to MPI_Type_create_hvector since OpenMPI does not support it. (Source: https://www.open-mpi.org/doc/v4.1/man3/MPI_Type_hvector.3.php#toc6 )
"Note that use of this routine is deprecated as of MPI-2. Use [MPI_Type_create_hvector](https://www.open-mpi.org/doc/v4.1/man3/MPI_Type_create_hvector.3.php) instead.
This deprecated routine is not available in C++."


2. The variable BulkEnergy never gets cleaned up from the c_solver class (iPIC3Dlib.cpp).